### PR TITLE
bug-fix:removed extra comma when all columns are not defined in dedup…

### DIFF
--- a/jupyterlab-amphi/packages/pipeline-components-core/src/components/transforms/Deduplicate.tsx
+++ b/jupyterlab-amphi/packages/pipeline-components-core/src/components/transforms/Deduplicate.tsx
@@ -39,9 +39,7 @@ export class Deduplicate extends BaseCoreComponent {
     // Initializing code string
     let code = `
 # Deduplicate rows\n`;
-    const columns = config.subset.length > 0 ? 
-    `subset=[${config.subset.map(column => column.named ? `"${column.value.trim()}"` : column.value).join(', ')}]` 
-    : '';
+    const columns = config.subset.length > 0 ? `subset=[${config.subset.map(column => column.named ? `"${column.value.trim()}"` : column.value).join(', ')}]` : '';
     const keep = typeof config.keep === 'boolean' ? (config.keep ? `"first"` : '') : `"${config.keep}"`;
 
     // Generating the Python code for deduplication

--- a/jupyterlab-amphi/packages/pipeline-components-core/src/components/transforms/Deduplicate.tsx
+++ b/jupyterlab-amphi/packages/pipeline-components-core/src/components/transforms/Deduplicate.tsx
@@ -39,11 +39,13 @@ export class Deduplicate extends BaseCoreComponent {
     // Initializing code string
     let code = `
 # Deduplicate rows\n`;
-    const columns = config.subset.length > 0 ? `subset=[${config.subset.map(column => column.named ? `"${column.value.trim()}"` : column.value).join(', ')}]` : '';
+    const columns = config.subset.length > 0 ? 
+    `subset=[${config.subset.map(column => column.named ? `"${column.value.trim()}"` : column.value).join(', ')}]` 
+    : '';
     const keep = typeof config.keep === 'boolean' ? (config.keep ? `"first"` : '') : `"${config.keep}"`;
 
     // Generating the Python code for deduplication
-    code += `${outputName} = ${inputName}.drop_duplicates(${columns}${keep ? `, keep=${keep}` : ''})\n`;
+    code += `${outputName} = ${inputName}.drop_duplicates(${columns}${columns && keep ? `, keep=${keep}` : !columns && keep ? `keep=${keep}` : ''})\n`;
 
     return code;
   }


### PR DESCRIPTION
If any columns are defined for deduplicate component, pipeline throw an exception. Condition is updated for this component, so if any column are defined will not add extra comma before keep parameter.