### PR TITLE
Variable CSV file encoding

### DIFF
--- a/jupyterlab-amphi/packages/pipeline-components-core/src/components/inputs/files/CsvFileInput.tsx
+++ b/jupyterlab-amphi/packages/pipeline-components-core/src/components/inputs/files/CsvFileInput.tsx
@@ -10,9 +10,7 @@ export class CsvFileInput extends BaseCoreComponent {
       fileLocation: "local",
       connectionMethod: "env",
       csvOptions: {
-        sep: ",",
-        encoding: "utf-8",
-        encoding_errors: "strict"
+        sep: ","
       }
     };
     const form = {

--- a/jupyterlab-amphi/packages/pipeline-components-core/src/components/inputs/files/CsvFileInput.tsx
+++ b/jupyterlab-amphi/packages/pipeline-components-core/src/components/inputs/files/CsvFileInput.tsx
@@ -65,7 +65,17 @@ export class CsvFileInput extends BaseCoreComponent {
               { value: "latin-1", label: "latin-1" },
               { value: "iso-8859-1", label: "ISO-8859-1" },
               { value: "cp1252", label: "cp1252" },
-              { value: "utf-16", label: "UTF-16" }
+              { value: "utf-16", label: "UTF-16" },
+              { value: "ascii", label: "ASCII" },
+              { value: "iso-8859-15", label: "ISO‑8859‑15" },
+              { value: "windows-1250", label: "Windows‑1250 (Central Europe)" },
+              { value: "windows-1251", label: "Windows‑1251 (Cyrillic)" },
+              { value: "koi8-r", label: "KOI8‑R (Russian Cyrillic)" },
+              { value: "koi8-u", label: "KOI8‑U (Ukrainian Cyrillic)" },
+              { value: "gbk", label: "GBK (Simplified Chinese)" },
+              { value: "big5", label: "Big5 (Traditional Chinese)" },
+              { value: "shift_jis", label: "Shift_JIS (Japanese)" },
+              { value: "euc-kr", label: "EUC‑KR (Korean)" },
           ],
           advanced: true
         },

--- a/jupyterlab-amphi/packages/pipeline-components-core/src/components/inputs/files/CsvFileInput.tsx
+++ b/jupyterlab-amphi/packages/pipeline-components-core/src/components/inputs/files/CsvFileInput.tsx
@@ -10,7 +10,9 @@ export class CsvFileInput extends BaseCoreComponent {
       fileLocation: "local",
       connectionMethod: "env",
       csvOptions: {
-        sep: ","
+        sep: ",",
+        encoding: "utf-8",
+        encoding_errors: "strict"
       }
     };
     const form = {
@@ -53,6 +55,21 @@ export class CsvFileInput extends BaseCoreComponent {
             { value: "|", label: "pipe (|)" },
             { value: "infer", label: "infer (tries to auto detect)" }
           ],
+        },
+        {
+          type: "selectCustomizable",
+          label: "Encoding",
+          id: "csvOptions.encoding",
+          placeholder: "Default: utf-8",
+          tooltip: "Select the character encoding of the file.",
+          options: [
+              { value: "utf-8", label: "UTF-8" },
+              { value: "latin-1", label: "latin-1" },
+              { value: "iso-8859-1", label: "ISO-8859-1" },
+              { value: "cp1252", label: "cp1252" },
+              { value: "utf-16", label: "UTF-16" }
+          ],
+          advanced: true
         },
         {
           type: "inputNumber",


### PR DESCRIPTION
### Problem
The `CSVFileInput` component current defaults to reading CSV files using UTF-8 encoding (as per [pandas.read_csv](https://pandas.pydata.org/docs/dev/reference/api/pandas.read_csv.html)) - which works for most cases but other character sets do exist, with a common Windows encoding being `cp1252`
 
Attempting to import a CSV with that encoding, I get an error;

> 'utf-8' codec can't decode byte 0x96 in position 4: invalid start byte

### Solution
This PR introduces an 'Encoding' dropdown to the `CSVFileInput` component, allowing users to explicitly select an encoding when reading the file.

This field updates the generated Python for the component.
By default, without an encoding set, there is no change
```python
csvFileInput1 = pd.read_csv("nonutf8.csv", sep=",").convert_dtypes()
```

When an encoding is selected, it gets templated in like;
```python
csvFileInput1 = pd.read_csv("nonutf8.csv", sep=",", encoding="cp1252").convert_dtypes()
```

### Testing/Caveats
I can confirm that this works for my CSV, the generated Python is updated as expected and I'm able to use the dataframe.

I've added a non-exhaustive list of the common used encodings to choose from, but have not tested each scenario. Python supports [many standard encodings](https://docs.python.org/3/library/codecs.html#standard-encodings). Not sure if it's worth pulling them all in.

I set the components' advanced key to true which at the moment doesn't do anything - but I can imagine it would be required if an 'advanced' section were to be implemented.