### PR TITLE
feat: Add DatePicker form component option

### DIFF
--- a/jupyterlab-amphi/packages/pipeline-components-manager/src/configUtils.tsx
+++ b/jupyterlab-amphi/packages/pipeline-components-manager/src/configUtils.tsx
@@ -22,7 +22,8 @@ import SelectRegular from './forms/selectRegular';
 import SelectTokenization from './forms/selectTokenization';
 import TransferData from './forms/transferData';
 import ValuesListForm from './forms/valuesListForm';
-import FormulaColumns from './forms/FormulaColumns'
+import FormulaColumns from './forms/FormulaColumns';
+import DatePickerForm from './forms/DatePickerForm';
 import { PipelineService } from './PipelineService';
 import { ThemeConsumer } from 'styled-components';
 import SelectSheetFromExcel from './forms/selectSheetFromExcel';
@@ -386,6 +387,8 @@ export const GenerateUIInputs = React.memo(({
         return renderFormItem(field, <DataMapping data={data} {...commonProps} defaultValue={values} componentService={componentService} commands={commands} nodeId={nodeId} />);
       case "formulaColumns":
         return renderFormItem(field, <FormulaColumns {...commonProps} defaultValue={value} componentService={componentService} commands={commands} nodeId={nodeId} />);
+      case "date":
+        return renderFormItem(field, <DatePickerForm {...commonProps} value={value} />);
       case "info":
         return <Typography.Paragraph style={{ padding: '5px' }}>{field.text}</Typography.Paragraph>;
       default:
@@ -588,7 +591,7 @@ export interface Option {
 export interface FieldDescriptor {
   type: 'file' | 'files' | 'column' | 'columns' | 'table' | 'keyvalue' | 'valuesList' | 'input' | 'password' | 'select' | 'textarea' | 'codeTextarea' | 'radio'
   | 'cascader' | 'boolean' | 'inputNumber' | 'selectCustomizable' | 'selectTokenization' | 'transferData' | 'keyvalueColumns' | 'keyvalueColumnsSelect' | 'sheets'
-  | 'dataMapping' | 'editableTable' | 'info' | 'cascaderMultiple' | 'selectMultipleCustomizable' | 'formulaColumns' | 'keyvalueColumnsRadio';
+  | 'dataMapping' | 'editableTable' | 'info' | 'cascaderMultiple' | 'selectMultipleCustomizable' | 'formulaColumns' | 'keyvalueColumnsRadio' | 'date';
   label: string;
   id: string;
   placeholder?: any;

--- a/jupyterlab-amphi/packages/pipeline-components-manager/src/forms/DatePickerForm.tsx
+++ b/jupyterlab-amphi/packages/pipeline-components-manager/src/forms/DatePickerForm.tsx
@@ -1,0 +1,39 @@
+import { DatePicker } from 'antd';
+import React from 'react';
+import dayjs from 'dayjs'; // Ant Design 5.x uses Day.js by default
+
+// Helper to ensure value is a Dayjs object if not null/undefined
+const ensureDayjs = (value: string | dayjs.Dayjs | undefined | null): dayjs.Dayjs | null => {
+  if (!value) {
+    return null;
+  }
+  if (dayjs.isDayjs(value)) {
+    return value;
+  }
+  // Attempt to parse if it's a string; adjust format as needed
+  const parsedDate = dayjs(value);
+  return parsedDate.isValid() ? parsedDate : null;
+};
+
+export const DatePickerForm = ({ field, value, handleChange, advanced }) => {
+  const handleDateChange = (date: dayjs.Dayjs | null, dateString: string) => {
+    // Pass the date string or Dayjs object based on how you want to store it
+    // For simplicity, passing dateString. If a Dayjs object is needed upstream, adjust this.
+    handleChange(field.id, dateString);
+  };
+
+  const dayjsValue = ensureDayjs(value);
+
+  return (
+    <DatePicker
+      id={field.id}
+      placeholder={field.placeholder ?? 'Select date'}
+      value={dayjsValue}
+      onChange={handleDateChange}
+      size={advanced ? "middle" : "small"}
+      style={{ width: '100%' }} // Standard styling for form components
+    />
+  );
+};
+
+export default React.memo(DatePickerForm);

--- a/jupyterlab-amphi/packages/pipeline-components-manager/src/forms/index.ts
+++ b/jupyterlab-amphi/packages/pipeline-components-manager/src/forms/index.ts
@@ -4,5 +4,6 @@ export { SelectRegular } from './selectRegular';
 export { SelectColumns } from './selectColumns';
 export { CodeTextarea } from './CodeTextarea';
 export { CodeTextareaMirror } from './CodeTextareaMirror';
+export { DatePickerForm } from './DatePickerForm';
 
 


### PR DESCRIPTION
Adds a new form input option using Ant Design's DatePicker.

Key changes:
- Created `DatePickerForm.tsx` under `jupyterlab-amphi/packages/pipeline-components-manager/src/forms/`. This component wraps `antd.DatePicker` and handles value conversion to/from Day.js objects.
- Exported `DatePickerForm` from `jupyterlab-amphi/packages/pipeline-components-manager/src/forms/index.ts`.
- Modified `jupyterlab-amphi/packages/pipeline-components-manager/src/configUtils.tsx`:
    - Added 'date' to the `FieldDescriptor` type union.
    - Added a case for 'date' in the `GenerateUIInputs` component's switch statement to render the `DatePickerForm`.
    - Imported `DatePickerForm`.

This allows pipeline component developers to specify `type: "date"` in their form field definitions to use the new DatePicker input.