### PR TITLE
feat: load components from TypeScript files

### DIFF
--- a/jupyterlab-amphi/packages/pipeline-components-manager/package.json
+++ b/jupyterlab-amphi/packages/pipeline-components-manager/package.json
@@ -53,6 +53,7 @@
     "@codemirror/lang-python": "^6.0.0",
     "@jupyterlab/application": "^4.1.5",
     "@jupyterlab/apputils": "^4.1.5",
+    "@jupyterlab/filebrowser": "^4.1.5",
     "@jupyterlab/completer": "^4.1.5",
     "@lumino/widgets": "^2.0.0",
     "@uiw/react-codemirror": "^4.22.0",
@@ -67,7 +68,8 @@
     "react-mentions": "^4.4.10",
     "react-select": "^5.8.0",
     "reactflow": "11.7.2",
-    "styled-components": "^6.1.8"
+    "styled-components": "^6.1.8",
+    "typescript": "~5.2.2"
   },
   "resolutions": {
     "antd": "5.24.4",
@@ -87,7 +89,6 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.1.1",
     "rimraf": "^3.0.2",
-    "typescript": "~5.2.2",
     "yarn-deduplicate": "^6.0.2"
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary
- add plugin to register components from `.ts` files through context menu
- include `@jupyterlab/filebrowser` and `typescript` runtime deps for dynamic loading

## Testing
- `yarn install` *(fails: Bad response 403)*
- `yarn run eslint:check` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7bc287cc8328ad78077b3007357b