### PR TITLE
feat: add end, stop branch or row component

### DIFF
--- a/jupyterlab-amphi/packages/pipeline-components-core/src/components/custom/EndOfBranch.tsx
+++ b/jupyterlab-amphi/packages/pipeline-components-core/src/components/custom/EndOfBranch.tsx
@@ -1,0 +1,40 @@
+import { codeIcon } from '../../icons';
+import { BaseCoreComponent } from '../BaseCoreComponent'; // Adjust the import path
+
+export class EndOfBranch extends BaseCoreComponent {
+  constructor() {
+    const defaultConfig = { inputName: "" };
+    const form = {
+      idPrefix: "component__form",
+      fields: [
+        {
+          type: "info",
+          label: "Stop, End of this Branch, Row",
+          id: "instructions",
+          text: "This is the component, that stop, end this branch, row.",
+        } 
+      ],
+    };
+
+    const description = "Use this component, when you want to stop, end this branch, row.";
+
+    super("Stop, End", "endOfBranch", description, "pandas_df_output", [], "outputs", codeIcon, defaultConfig, form);
+  }
+
+  public provideImports({ config }): string[] {
+    return [];
+  }
+
+  public provideDependencies({ config }): string[] { 
+    return [];
+  }
+
+  public generateComponentCode({ config, inputName }): string { 
+    console.log("With config:", config);
+
+    return `\n
+    # End of Branch reached. No further processing. 
+    print(f"End of branch reached for customTitle: ${config.customTitle}")
+    \n`;
+  }
+}

--- a/jupyterlab-amphi/packages/pipeline-components-core/src/components/index.ts
+++ b/jupyterlab-amphi/packages/pipeline-components-core/src/components/index.ts
@@ -95,3 +95,56 @@ export { FormExample } from './developer/FormExample';
 export { DataframeList } from './developer/DataframeList';
 export { DataframeDelete } from './developer/DataframeDelete';
 export { PackagesList } from './developer/PackagesList';
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+export { EndOfBranch } from './custom/EndOfBranch';

--- a/jupyterlab-amphi/packages/pipeline-components-core/src/index.ts
+++ b/jupyterlab-amphi/packages/pipeline-components-core/src/index.ts
@@ -14,7 +14,26 @@ import {
   EnvVariables, EnvFile, Transpose, Unite, Pivot, Annotation, ODBCInput, PdfTablesInput, Summary, LocalFileInput, FlattenJSON,
   DataCleansing, GenerateIDColumn, SqlServerInput, OracleInput, Connection, SnowflakeInput, FormulaRow, InlineInput, S3FileOutput, S3FileInput, 
   SnowflakeOutput, SqlServerOutput, OracleOutput, CustomInput, CustomOutput, FileUtils, FrequencyAnalysis, FormExample,UniqueKeyDetector,FileAction,DataframeList,DataframeDelete,HierarchyPath,PackagesList, JSONTools,
-  DatabaseInput, DatabaseOutput, CompareDataframes, GenerateCalendar, DynamicGenerateCalendar
+  DatabaseInput, DatabaseOutput, CompareDataframes, GenerateCalendar, DynamicGenerateCalendar,
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  EndOfBranch
 } from './components';
 
 // Export allow the component to be used as a base component in different packages
@@ -23,7 +42,25 @@ export { Aggregate, Console, ExcelFileOutput, CsvFileInput, JsonFileInput, JsonF
   ParquetFileInput, ParquetFileOutput, PostgresInput, PostgresOutput, MySQLInput, MySQLOutput, XmlFileInput, XmlFileOutput, DateTimeConverter,
   EnvVariables, EnvFile, Transpose, Unite, Pivot, Annotation, ODBCInput, PdfTablesInput, Summary, LocalFileInput, FlattenJSON,
   DataCleansing, GenerateIDColumn, SqlServerInput, OracleInput, Connection, SnowflakeInput, FormulaRow, InlineInput, S3FileOutput, S3FileInput,
-  SnowflakeOutput, SqlServerOutput, OracleOutput, CustomInput, CustomOutput, FileUtils, FrequencyAnalysis, FormExample,UniqueKeyDetector,FileAction,DataframeList,DataframeDelete,HierarchyPath,PackagesList,CompareDataframes,GenerateCalendar,DynamicGenerateCalendar 
+  SnowflakeOutput, SqlServerOutput, OracleOutput, CustomInput, CustomOutput, FileUtils, FrequencyAnalysis, FormExample,UniqueKeyDetector,FileAction,DataframeList,DataframeDelete,HierarchyPath,PackagesList,CompareDataframes,GenerateCalendar,DynamicGenerateCalendar ,
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  EndOfBranch
   }
 
 const plugin: JupyterFrontEndPlugin<void> = {
@@ -121,6 +158,39 @@ const plugin: JupyterFrontEndPlugin<void> = {
     componentService.addComponent(DataframeList.getInstance())
     componentService.addComponent(DataframeDelete.getInstance())
 	componentService.addComponent(PackagesList.getInstance())
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    componentService.addComponent(EndOfBranch.getInstance())
   }
 };
 


### PR DESCRIPTION
End of Branch is a companion to the Switch component. When a user only needs one path (e.g. the True path), the other path has no output. This causes a problem when exporting to Python/Dagster — the export function expects every branch in the graph to be closed with an output. Without EndOfBranch, the Switch component can't be used in export scenarios where only one path is needed.
Ideally the export logic itself could be updated to handle open branches gracefully, which would remove the need for this component. But for now, EndOfBranch is a practical workaround that lets users actually use the Switch component end-to-end.